### PR TITLE
Add Smart Plug Device Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,31 +12,45 @@ by [Colorado Four Wheeler](https://github.com/colorado4wheeler).
 
 - [RM Pro+](https://www.amazon.com/Broadlink-RM33-RM-Pro-Automation/dp/B078W1JVYK)
 - [RM3 Mini3](https://www.amazon.com/Broadlink-RM33-RM-Pro-Automation/dp/B078BCMZH6)
+- [SP3 Smart Plug](https://www.amazon.com/BroadLink-Required-Control-Occupies-Assistant/dp/B01FDGO948)
 
-Other IR devices may work. Let me know!
+Other IR and SP devices may work. Let me know!
 
 ## Future Devices
 
-This plugin does not expose any of the RF capabilities of the RM devices. If you
-would like these features, help me figure it out. I don't have any RF equipment.
+**This plugin does not expose any of the RF capabilities of the RM devices.** *If you
+would like these features, help me figure it out. I don't have any RF equipment.*
+
+*This plugin does not expose the energy reading capabilities of the SP3S. I hope
+to have an SP3S soon to test with.*
 
 Other Broadlink devices I'd like to include in future revisions:
 
 - [A1 Environment Sensors](http://www.ibroadlink.com/a1/)
-- [SP2/3 Smart Plugs](http://www.ibroadlink.com/sp3/)
+
+Let me know if you'd like others!
 
 ## Usage
 
 1. [Download the latest release](https://github.com/davidnewhall/indigo-broadlink/archive/latest.zip) or clone this repo.
-2. Double-click the included plugin file.
-3. Install and Enable the Plugin.
-4. Add a New Device, Select `Broadlink Devices`, then `RM Universal Remote`.
-5. Choose a device type: `RM Pro+`, `RM3 Mini`, etc.
-6. Click `Discover`. If it fails, enter the IP for the RM device manually.
-7. Click `Learn Command`. Point your remote and press a button.
-8. Give it a name and Click `Add Command`. << *Important*
-9. Click `Save`.
-10. Use the Commands in Action Groups, Triggers or Schedules.
+1. Double-click the included plugin file.
+1. Install and Enable the Plugin.
+1. Add a New Device, Select `Broadlink Devices`, then `RM Universal Remote` or `Smart Plug`.
+1. Click `Discover`. If it fails, enter the `IP` and `Model` for the device manually.
+    - Check Indigo server logs after discovery for discovery details.
+
+#### RM Universal Remote
+
+1. Click `Learn Command`. Point your remote and press a button.
+1. Give it a name and Click `Add Command`. << *Important*
+1. Click `Save`.
+1. Use the Commands in Action Groups, Triggers or Schedules.
+
+#### Smart Plugs
+
+These devices have no special states. Select an update interval in the plugin
+configuration; this ensures local state changes are reported as expected.
+Control these devices with On/Off commands as you would any other relay device.
 
 ## Licenses
 

--- a/broadlink.indigoPlugin/Contents/Info.plist
+++ b/broadlink.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>1.0.9</string>
+	<string>1.1.0</string>
 	<key>ServerApiVersion</key>
 	<string>2.0</string>
 	<key>IwsApiVersion</key>

--- a/broadlink.indigoPlugin/Contents/Info.plist
+++ b/broadlink.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>1.0.0</string>
+	<string>1.0.9</string>
 	<key>ServerApiVersion</key>
 	<string>2.0</string>
 	<key>IwsApiVersion</key>

--- a/broadlink.indigoPlugin/Contents/Server Plugin/Actions.xml
+++ b/broadlink.indigoPlugin/Contents/Server Plugin/Actions.xml
@@ -3,32 +3,32 @@
 
 	<Action id="sendRawCommand" deviceFilter="self">
 		<Name>Send Raw Command</Name>
-		<CallbackMethod>_send_command</CallbackMethod>
+		<CallbackMethod>_send_IR_command</CallbackMethod>
 		<ConfigUI>
 			<Field id="rawCommand" type="textfield">
 				<Label>Raw Command:</Label>
 			</Field>
 			<Field id="learnNewCommand" type="button">
 				<Title>Learn</Title>
-				<CallbackMethod>_learn_new_command</CallbackMethod>
+				<CallbackMethod>_learn_new_IR_command</CallbackMethod>
 			</Field>
 		</ConfigUI>
 	</Action>
 
 	<Action id="sendSavedCommand" deviceFilter="self">
 		<Name>Send Saved Command</Name>
-		<CallbackMethod>_send_command</CallbackMethod>
+		<CallbackMethod>_send_IR_command</CallbackMethod>
 		<ConfigUI>
 			<Field id="rawCommand" type="menu">
 				<Label>Saved Command:</Label>
-				<List class="self" method="_get_saved_commands_list" />
+				<List class="self" method="_get_saved_IR_commands_list" />
 			</Field>
 		</ConfigUI>
 	</Action>
 
 	<Action id="resetCommandCounter" deviceFilter="self">
 		<Name>Reset Command Counter</Name>
-		<CallbackMethod>_reset_command_counter</CallbackMethod>
+		<CallbackMethod>_reset_IR_command_counter</CallbackMethod>
 	</Action>
 
 </Actions>

--- a/broadlink.indigoPlugin/Contents/Server Plugin/Devices.xml
+++ b/broadlink.indigoPlugin/Contents/Server Plugin/Devices.xml
@@ -37,12 +37,12 @@
 			</Field>
 			<Field id="savedCommandList" type="list" rows="5">
 				<Label>Saved Commands:</Label>
-				<List class="self" method="_get_saved_commands_list" dynamicReload="true"/>
+				<List class="self" method="_get_saved_IR_commands_list" dynamicReload="true"/>
 			</Field>
 			<Field id="deleteSavedCommands" type="button">
 				<Label/>
 				<Title>Delete Command(s)</Title>
-				<CallbackMethod>_delete_saved_commands</CallbackMethod>
+				<CallbackMethod>_delete_saved_IR_commands</CallbackMethod>
 			</Field>
 			<Field id="reminder" type="label" fontSize="regular" fontColor="darkgray">
 				<Label>Remember to click Save to keep changes to this list!</Label>
@@ -53,12 +53,12 @@
 			<Field id="commandName" type="textfield">
 				<Label>New Command Name:</Label>
 			</Field>
-			<Field id="rawCommand" type="textfield">
+			<Field id="rawCommand" type="textfield" defaultValue="">
 				<Label>Raw Command:</Label>
 			</Field>
 			<Field id="learnNewCommand" type="button">
 				<Title>Learn Command</Title>
-				<CallbackMethod>_learn_new_command</CallbackMethod>
+				<CallbackMethod>_learn_new_IR_command</CallbackMethod>
 			</Field>
 			<Field id="instructions" type="label" fontSize="regular" fontColor="darkgray">
 				<Label>Click Learn Command, then point your remote and press a button.</Label>
@@ -66,7 +66,7 @@
 			<Field id="saveNewCommand" type="button">
 				<Label>Save Learned Command:</Label>
 				<Title>Add Command</Title>
-				<CallbackMethod>_save_new_command</CallbackMethod>
+				<CallbackMethod>_save_new_IR_command</CallbackMethod>
 			</Field>
 
 			<Field id="logChanges" type="checkbox" defaultValue="true">

--- a/broadlink.indigoPlugin/Contents/Server Plugin/Devices.xml
+++ b/broadlink.indigoPlugin/Contents/Server Plugin/Devices.xml
@@ -96,4 +96,53 @@
 
 		</States>
 	</Device>
+
+	<Device type="relay" id="spDevice">
+		<Name>Smart Plug (SP2/SP3)</Name>
+		<ConfigUI>
+			<Field type="menu" id="model" defaultValue="0x2711">
+				<Label>Model:</Label>
+				<List>
+					<Option value="0x2711">SP2</Option>
+					<Option value="0x2719">Honeywell SP2</Option>
+					<Option value="0x7919">Honeywell SP2</Option>
+					<Option value="0x271a">Honeywell SP2</Option>
+					<Option value="0x791a">Honeywell SP2</Option>
+					<Option value="0x2720">SPMini</Option>
+					<Option value="0x753e">SP3</Option>
+					<Option value="0x7D00">OEM branded SP3</Option>
+					<Option value="0x947a">SP3S</Option>
+					<Option value="0x9479">SP3S</Option>
+					<Option value="0x2728">SPMini2</Option>
+					<Option value="0x2733">OEM branded SPMini</Option>
+					<Option value="0x273e">OEM branded SPMini</Option>
+					<Option value="0x7530">OEM branded SPMini2</Option>
+					<Option value="0x7918">OEM branded SPMini2</Option>
+					<Option value="0x2736">SPMiniPlus</Option>
+				</List>
+			</Field>
+
+			<Field id="address" type="textfield" defaultValue="192.168.1.199">
+				<Label>IP Address:</Label>
+			</Field>
+			<Field id="discoverDevice" type="button">
+				<Title>Discover</Title>
+				<CallbackMethod>_discover_device</CallbackMethod>
+			</Field>
+			<Field type="separator" id="simpleSeparator0" />
+			<Field id="supportsAllOff" type="checkbox" defaultValue="false">
+				<Label>Respond to All Devices Off</Label>
+			</Field>
+			<Field id="supportsAllLights" type="checkbox" defaultValue="false">
+				<Label>Respond to All Lights On/Off</Label>
+			</Field>
+			<Field type="separator" id="simpleSeparator1" />
+			<Field id="logChanges" type="checkbox" defaultValue="true">
+				<Label>Record Changes to Indigo Log</Label>
+			</Field>
+			<Field id="logActions" type="checkbox" defaultValue="true">
+				<Label>Record Actions to Indigo Log</Label>
+			</Field>
+		</ConfigUI>
+	</Device>
 </Devices>

--- a/broadlink.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
+++ b/broadlink.indigoPlugin/Contents/Server Plugin/PluginConfig.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<PluginConfig>
+	<SupportURL>https://github.com/davidnewhall/indigo-broadlink/</SupportURL>
+
+	<Field type="menu" id="interval" defaultValue="30">
+		<Label>Update Interval:</Label>
+		<List>
+			<Option value="2">2 seconds</Option>
+			<Option value="5">5 seconds</Option>
+			<Option value="15">15 seconds</Option>
+			<Option value="30">30 seconds</Option>
+			<Option value="60">1 minute</Option>
+			<Option value="90">1.5 minutes</Option>
+			<Option value="120">2 minutes</Option>
+		</List>
+	</Field>
+
+	<Field id="instructions0" type="label" fontSize="regular" fontColor="darkgray">
+		<Label>Set this to a longer interval if you have many pollable devices.</Label>
+	</Field>
+
+	<Field type="menu" id="timeout" defaultValue="8">
+		<Label>Request Timeout:</Label>
+		<List>
+			<Option value="3">3 seconds</Option>
+			<Option value="4">4 seconds</Option>
+			<Option value="6">6 seconds</Option>
+			<Option value="8">8 seconds</Option>
+			<Option value="9">9 seconds</Option>
+			<Option value="10">10 seconds</Option>
+			<Option value="15">15 seconds</Option>
+		</List>
+	</Field>
+	<Field id="instructions1" type="label" fontSize="regular" fontColor="darkgray">
+		<Label>A timeout of 6-10 seconds works well.</Label>
+	</Field>
+</PluginConfig>

--- a/scripts/discover.py
+++ b/scripts/discover.py
@@ -1,13 +1,19 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
+""" Broadlink Device Discovery Script """
 
 import broadlink
 
 
-print "discovering"
-devices = broadlink.discover(timeout=9)
-print devices
-for device in devices:
-    if device.auth():
-        print device.host[0]
-    else:
-        print "Error authenticating with device : {}".format(device.host)
+def main():
+    """ Discover things. """
+    print("Discovering! please wait a moment...")
+    devices = broadlink.discover(timeout=8)
+    print("Found: {} devices".format(len(devices)))
+
+    for device in devices:
+        print("HEX Type: {} - IP Address: {}".format(hex(device.devtype), device.host[0]))
+        if not device.auth():
+            print("Error communicating with device: {}".format(device.host))
+
+
+main()

--- a/scripts/read_command.py
+++ b/scripts/read_command.py
@@ -1,30 +1,32 @@
 #!/usr/bin/env python
+""" Read a command from an RM/RM2/RM3/RMmini. """
 
 import time
 import broadlink
 
 DEVICE_IP = "192.168.1.235"
-RM_PRO_PLUS_DEV = "0x2712"
+DEVICE_ID = "0x2712"
 
 
 def main():
-    """ Read a command. """
-    rm_pro_dev = broadlink.gendevice(int(RM_PRO_PLUS_DEV, 0), (DEVICE_IP, 80), "000000000000")
-    print "reading command from " + DEVICE_IP
-    rm_pro_dev.auth()
+    """ Read a command from an RM/RM2/RM3/RMmini. """
+    device = broadlink.gendevice(int(DEVICE_ID, 0), (DEVICE_IP, 80), "000000000000")
+    print("reading command from {}".format(DEVICE_IP))
+    device.auth()
 
-    rm_pro_dev.enter_learning()
+    device.enter_learning()
     data = None
-    print "Learning..."
+    print("Learning... (push a button)")
     timeout = 30
 
     while (data is None) and (timeout > 0):
         time.sleep(1)
         timeout -= 1
-        data = rm_pro_dev.check_data()
+        data = device.check_data()
 
     if data:
-        print ''.join(format(x, '02x') for x in bytearray(data))
+        print("Captured command!")
+        print("".join(format(x, "02x") for x in bytearray(data)))
 
 
 main()

--- a/scripts/send_command.py
+++ b/scripts/send_command.py
@@ -1,22 +1,20 @@
 #!/usr/bin/env python
+""" Send a command to an RM/RM2/RM3/RMmini. """
 
 import broadlink
 
-
 DEVICE_IP = "192.168.1.235"
+DEVICE_ID = "0x2712"
 IR_COMMAND = "2600500000012695121411391114113912381238123911141139121312381214111410151114123812391139111411391238121411141114111411141139121312141139113911391200051e0001274b11000d050000000000000000"
-
-RM_PRO_PLUS_DEV = "0x2712"
 
 
 def main():
     """ Send a command. """
-    rm_pro_dev = broadlink.gendevice(int(RM_PRO_PLUS_DEV, 0), (DEVICE_IP, 80), "000000000000")
-    print "sending command to " + DEVICE_IP
-    rm_pro_dev.auth()
-
+    device = broadlink.gendevice(int(DEVICE_ID, 0), (DEVICE_IP, 80), "000000000000")
+    print("Sending command to {}".format(DEVICE_IP))
+    device.auth()
     data = bytearray.fromhex(''.join(IR_COMMAND))
-    rm_pro_dev.send_data(data)
+    device.send_data(data)
 
 
 main()

--- a/scripts/sp.py
+++ b/scripts/sp.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python2.7
+""" Check that things work on an SP2/SP3/SP3S/SPmini device. """
+
+import time
+import broadlink
+
+DEVICE_IP = "192.168.1.201"  # This is important. Find it with discover.py.
+DEVICE_ID = "0x2711"  # This probably makes no difference.
+#            0x2711,                          # SP2
+#            0x2719, 0x7919, 0x271a, 0x791a,  # Honeywell SP2
+#            0x2720,                          # SPMini
+#            0x753e,                          # SP3
+#            0x7D00,                          # OEM branded SP3
+#            0x947a, 0x9479,                  # SP3S
+#            0x2728,                          # SPMini2
+#            0x2733, 0x273e,                  # OEM branded SPMini
+#            0x7530, 0x7918,                  # OEM branded SPMini2
+#            0x2736                           # SPMiniPlus
+
+
+def main():
+    """ Read Device State. """
+    device = broadlink.gendevice(int(DEVICE_ID, 0), (DEVICE_IP, 80), "000000000000")
+    print("Checking State: {}".format(DEVICE_IP))
+    # Not sure why this fails on python 3.7
+    device.auth()
+
+    state = device.check_power()
+    print("Current State: {}".format(state))
+    try:
+        energy = device.get_energy()
+        print("Energy State: {}".format(energy))
+    except ValueError:
+        # May not support energy metering.
+        pass
+
+    print("Turning device off.")
+    device.set_power(False)
+    print("Sleeping 5 seconds.")
+    time.sleep(5)
+    print("Turning device on.")
+    device.set_power(True)
+
+
+main()


### PR DESCRIPTION
This contributions:
- Adds support for Smart Plug devices (SP3, SP2, etc).
- Improves logging when discovering more than 1 devices.
- Updates stand-alone discovery scripts.
- Renames IR functions to be more obvious.
- Attempts to auto-populate model when discovering. Still not great when > 1 device is discovered.
- Adds configurable broadlink timeout.
- Adds configurable polling interval for SP devices. Will handle A1 (and other poll-able) devices in the future.