### PR TITLE
Squash bugs with correct default values.

### DIFF
--- a/broadlink.indigoPlugin/Contents/Server Plugin/Devices.xml
+++ b/broadlink.indigoPlugin/Contents/Server Plugin/Devices.xml
@@ -6,7 +6,7 @@
 			<Field id="category" type="textfield" hidden="true" defaultValue="IR">
 				<Label>Device Category</Label>
 			</Field>
-			<Field type="menu" id="model" defaultValue="0x2712" >
+			<Field type="menu" id="model" defaultValue="">
 				<Label>Model:</Label>
 				<List class="self" method="_list_known_devices" filter="IR" dynamicReload="false"/>
 			</Field>
@@ -21,7 +21,7 @@
 			</Field>
 			<Field type="separator" id="simpleSeparator0" />
 
-			<Field id="commands" type="textfield" hidden="true">
+			<Field id="commands" type="textfield" hidden="true" defaultValue="[]">
 				<Label>Commands</Label>
 			</Field>
 			<Field id="savedCommandList" type="list" rows="5">
@@ -98,7 +98,7 @@
 			<Field id="category" type="textfield" hidden="true" defaultValue="SP">
 				<Label>Device Category</Label>
 			</Field>
-			<Field type="menu" id="model" defaultValue="0x2711">
+			<Field type="menu" id="model" defaultValue="">
 				<Label>Model:</Label>
 				<List class="self" method="_list_known_devices" filter="SP" dynamicReload="false"/>
 			</Field>
@@ -132,7 +132,7 @@
 			<Field id="category" type="textfield" hidden="true" defaultValue="SC">
 				<Label>Device Category</Label>
 			</Field>
-			<Field type="menu" id="model" defaultValue="0x2711">
+			<Field type="menu" id="model" defaultValue="">
 				<Label>Model:</Label>
 				<List class="self" method="_list_known_devices" filter="SC" dynamicReload="false"/>
 			</Field>

--- a/broadlink.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/broadlink.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -103,9 +103,9 @@ class Plugin(indigo.PluginBase):
             # If there's more than one discovered device, only one is populated
             # in the UI, but all of them are printed into the log file, in red.
             indigo.server.log(
-                u"Discovered Device: {0}|{1} - type: {2}, IP: {3}, Auth: {4}".format(
+                u"Discovered Device: {0}|{1} - type: {2}, IP: {3}, Auth: {4}, Device: {5}".format(
                     model_cat, model_name, values["model"], device.host[0],
-                    values["address"] == device.host[0]),
+                    values["address"] == device.host[0], values["address"] in exclude),
                 isError=(len(devices) > 1))
             if values.get("category", model_cat) == model_cat and device.host[0] not in exclude:
                 # If we find a device with a new IP in the same category, use it.
@@ -113,14 +113,17 @@ class Plugin(indigo.PluginBase):
         # return the special one, or the last one found
         if return_values is not None:
             (values["model"], values["address"]) = return_values
+        if values["model"] not in MODELS[values["category"]]:
+            # Avoid setting Model to '- select an item -'
+            del values["model"]
         return values
 
     def _get_saved_IR_commands_list(self, dev_filter, values, type_id, did):
         """ Devices.xml Callback Method to return saved commands for this device. """
         dev = indigo.devices[did]
-        if "commands" not in dev.pluginProps:
-            return [("none", "- none -")]
-        return json.loads(dev.pluginProps["commands"])
+        if "commands" in dev.pluginProps and dev.pluginProps["commands"] not in ["", "[]"]:
+            return json.loads(dev.pluginProps["commands"])
+        return [("none", "- none -")]
 
     def _delete_saved_IR_commands(self, values, type_id, did):
         """ Devices.xml Callback Method to delete saved commands. """


### PR DESCRIPTION
For whatever reason, Indigo was failing to use the provided default values in the UI pages. The alternative is to leave them blank, and Indigo will take the first item in the returned list as the default. That's also a crock because it's a dict and has no order. derp. This at least removes the bugs and allows the IR devices to be configured without workarounds.

Not updating version yet since I'm going to release a new feature with this bug fix.